### PR TITLE
Add PRIORITY_OUTCOMES property to Pathology Notes node

### DIFF
--- a/gdcdictionary/schemas/progress_note.yaml
+++ b/gdcdictionary/schemas/progress_note.yaml
@@ -83,6 +83,8 @@ properties:
     description: raw text of progress note
   priority_outcomes:
     type: array
+    items:
+      type: string
     description: List of top priority outcomes extracted from progress note text (Note_Narr)
 
   subject:

--- a/gdcdictionary/schemas/progress_note.yaml
+++ b/gdcdictionary/schemas/progress_note.yaml
@@ -81,6 +81,9 @@ properties:
   Note_Narr:
     type: string
     description: raw text of progress note
+  priority_outcomes:
+    type: array
+    description: List of top priority outcomes extracted from progress note text (Note_Narr)
 
   subject:
     description: The submitter_id or id of the subject this progress note belongs to, i.e., a link to a record in the parent node.

--- a/gdcdictionary/schemas/progress_note.yaml
+++ b/gdcdictionary/schemas/progress_note.yaml
@@ -85,7 +85,7 @@ properties:
     type: array
     items:
       type: string
-    description: List of top priority outcomes extracted from progress note text (Note_Narr)
+    description: List of priority outcomes extracted from progress note text (Note_Narr)
 
   subject:
     description: The submitter_id or id of the subject this progress note belongs to, i.e., a link to a record in the parent node.

--- a/gdcdictionary/schemas/progress_note.yaml
+++ b/gdcdictionary/schemas/progress_note.yaml
@@ -81,7 +81,7 @@ properties:
   Note_Narr:
     type: string
     description: raw text of progress note
-  priority_outcomes:
+  PRIORITY_OUTCOMES:
     type: array
     items:
       type: string


### PR DESCRIPTION
PRIORITY_OUTCOMES will be used to contain a list of priority outcomes extracted from Note_Narr